### PR TITLE
fix(fake-death): fix client death-restart sync (stuck Game Over, stale corpse, blocked doors)

### DIFF
--- a/FakeDeath/FakeDeath.cs
+++ b/FakeDeath/FakeDeath.cs
@@ -1529,7 +1529,10 @@ namespace DeadCellsMultiplayerMod
 
             try
             {
-                instance.ResetFakeDeathState(unlockLocalHero: true, sendNetworkUpState: false);
+                // Broadcast the revived (not-downed) state on restart so the peer clears its stale
+                // remote-downed tracking; otherwise the host keeps pinning this player as a corpse
+                // and gates interactions (e.g. exit doors) as if still downed.
+                instance.ResetFakeDeathState(unlockLocalHero: true, sendNetworkUpState: true);
             }
             catch
             {

--- a/LevelSync.cs
+++ b/LevelSync.cs
@@ -199,6 +199,28 @@ namespace DeadCellsMultiplayerMod
             });
         }
 
+        /// <summary>
+        /// In-place reloadAfterBossRuneModif keeps the current hero and only regenerates the level. It must be
+        /// suppressed while the local player is downed/Game Over or a full-run restart is pending, otherwise the
+        /// host's restart-level graph reloads the old downed run in place (no heal, Game Over stuck) or crashes
+        /// with a Null access .curCine — instead of letting the queued launchGame restart take over.
+        /// </summary>
+        private static bool ShouldSuppressClientLevelReload()
+        {
+            try
+            {
+                if (ModEntry.IsLocalPlayerDowned())
+                    return true;
+                if (GameMenu.IsClientRestartPending())
+                    return true;
+            }
+            catch
+            {
+            }
+
+            return false;
+        }
+
         private static void TryTriggerLevelGraphReload(string graphLevelId, string payload)
         {
             if (string.IsNullOrWhiteSpace(graphLevelId) || string.IsNullOrWhiteSpace(payload))
@@ -207,6 +229,12 @@ namespace DeadCellsMultiplayerMod
             var net = GameMenu.NetRef;
             if (net == null || !net.IsAlive || net.IsHost)
                 return;
+
+            if (ShouldSuppressClientLevelReload())
+            {
+                _log?.Information("[NetMod] Skipping level-graph reload for {LevelId}: client downed/restart pending", graphLevelId);
+                return;
+            }
 
             var hero = ModEntry.me;
             var level = hero?._level;
@@ -270,6 +298,12 @@ namespace DeadCellsMultiplayerMod
             var net = GameMenu.NetRef;
             if (net == null || !net.IsAlive || net.IsHost)
                 return;
+
+            if (ShouldSuppressClientLevelReload())
+            {
+                _log?.Information("[NetMod] Skipping boss-rune reload for {LevelId}: client downed/restart pending", graphLevelId);
+                return;
+            }
 
             var hero = ModEntry.me;
             var level = hero?._level;

--- a/UI/GameMenu.cs
+++ b/UI/GameMenu.cs
@@ -79,6 +79,11 @@ namespace DeadCellsMultiplayerMod
         private static DateTime _autoStartRetryAt = DateTime.MinValue;
         private const int DeathRestartCooldownMs = 1000;
         private static DateTime _deathRestartCooldownUntil = DateTime.MinValue;
+        // While a client full-run restart (from host seed) is pending, the host's freshly broadcast level
+        // graph for the restart level must NOT trigger an in-place reloadAfterBossRuneModif on the client:
+        // that collides with the queued launchGame restart and leaves the old downed hero / Game Over stuck.
+        private static long _clientRestartPendingUntilTicks;
+        private const int ClientRestartPendingTtlMs = 12000;
         private const string AutoStartMutexName = "DeadCellsMultiplayerMod.AutoStart";
         private static bool _mainMenuButtonAdded;
         private static bool _suppressAutoButton;
@@ -357,6 +362,24 @@ namespace DeadCellsMultiplayerMod
             {
                 _inActualRun = true;
             }
+            // The (re)started run's hero is up — the restart completed, so stop suppressing level reloads.
+            ClearClientRestartPending();
+        }
+
+        internal static void MarkClientRestartPending()
+        {
+            Volatile.Write(ref _clientRestartPendingUntilTicks, Environment.TickCount64 + ClientRestartPendingTtlMs);
+        }
+
+        internal static void ClearClientRestartPending()
+        {
+            Volatile.Write(ref _clientRestartPendingUntilTicks, 0);
+        }
+
+        internal static bool IsClientRestartPending()
+        {
+            var until = Volatile.Read(ref _clientRestartPendingUntilTicks);
+            return until != 0 && Environment.TickCount64 < until;
         }
 
         public static void SetRole(NetRole role)
@@ -489,6 +512,9 @@ namespace DeadCellsMultiplayerMod
 
         private static void QueueClientRestartFromHostSeed(int seed, string reason)
         {
+            // Set synchronously (before the queued action runs) so any level graph that arrives in the
+            // meantime is prevented from firing an in-place reload that would pre-empt this full restart.
+            MarkClientRestartPending();
             EnqueueMainThread(() =>
             {
                 ModEntry.ResetDownedPlayersForRestart();


### PR DESCRIPTION
## Problem

In co-op, when both players go down and the host restarts the run (all-players-downed), the **client** could end up:

- Stuck on the **Game Over** screen at 1 HP — never respawning or healing, sometimes crashing with `Null access .curCine`.
- After the host's restart, the **host kept seeing the client as a corpse** pinned at the old death position, and the client **could not interact with doors** (exit doors gated as if still downed).

## Reproduction

1. Two players in co-op.
2. Client goes down first, then the host goes down (all players downed → host restarts the run).
3. Observe the client.

## Root cause

**1. In-place level reload pre-empts the full restart (stuck Game Over / crash).**
On the all-downed restart the host broadcasts a new run seed + the new level graph. On the client:
- the seed triggers `QueueClientRestartFromHostSeed` → a queued full `launchGame` restart;
- the level graph then triggers `TryTriggerLevelGraphReload` → an in-place `reloadAfterBossRuneModif`, which runs **first** and reloads the *old* run in place, swallowing the full restart. The client is left in the old run at 1 HP with Game Over; a bad `curCine` state can crash with `Null access .curCine`.

**2. Revived state never broadcast (stale corpse + blocked doors).**
`ResetDownedPlayersForRestart` called `ResetFakeDeathState(sendNetworkUpState: false)`, so the restarting client never told the peer it was no longer downed. The host's `_remoteDowned[client]` stayed set, so `ReceiveGhostCoords` pinned the client ghost at the corpse position and `LevelExitSync` gated its interactions.

## Fix

- **LevelSync**: guard `TryTriggerLevelGraphReload` / `TryTriggerBossRuneReload` with `ShouldSuppressClientLevelReload()` — skip the in-place reload while the local player is downed or a full restart is pending, so the queued `launchGame` restart wins. Map consistency is unaffected (still synced via `generateGraph` + `TryApplyRemoteLevelGraph`).
- **GameMenu**: add a client-restart-pending flag (set when `QueueClientRestartFromHostSeed` queues, cleared on `MarkInRun`) to cover the window where `_localFakeDead` is already cleared but the new run hasn't started yet.
- **FakeDeath**: `ResetDownedPlayersForRestart` now broadcasts the not-downed state (`sendNetworkUpState: true`) so the peer clears stale remote-downed tracking.

## Notes

- Trade-off: while a full restart is pending, the client skips the in-place hot-reload of the current level; the host changing the boss rune mid-level is reflected on next level entry instead of instantly. Normal forward progression is unaffected.
- Verified in a live 2-player session (client-first death → host death → restart): client now respawns at the start level at full HP, the host sees the client move normally (no corpse), and door interactions work.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
